### PR TITLE
Resource Relationship Restructure, Schema Cleanup

### DIFF
--- a/tests/sample.py
+++ b/tests/sample.py
@@ -2,6 +2,8 @@
     Sample Functions
 """
 
+from datetime import datetime
+
 base_url = "http://127.0.0.1:5000"
 post_url = f"{base_url}/api/posts"
 author_url = f"{base_url}/api/authors"
@@ -13,41 +15,33 @@ poll_url = f"{base_url}/api/polls"
 # MOCK DATA
 
 
-def make_mock_article(author=None, id='1', title='A Test Article', cover_img=None, category=None):
+def make_mock_article(authorId='1', id='1', title='A Test Article', cover_img='1', category=None):
     """Create Mock Article"""
     mock_cover = cover_img or make_mock_media()
-    mock_author = author or make_mock_author()
+    mock_author = authorId or make_mock_author()
     mock_category = category or make_mock_category()
     mock_post = {
         'postId': id,
         'title': title,
-        'author': {
-            'authorId': mock_author['authorId']
-        },
-        'categories': mock_category,
-        'type': 'article',
-        'cover_image': mock_cover,
-        'content': 'Filler Content!',
-        'date': '2018-11-13T21:23:13'
+        'date': datetime.utcnow().isoformat(),
+        'content': "A Test Publication",
+        'author': authorId,
+        'cover_image': cover_img,
+        "categories": category,
+        'type': 'article'
     }
     return mock_post
 
 
-def make_mock_author(id='1', name='A Test Author'):
-    mock_profile = {
-        'name': name,
-        'source': 'https://bit.ly/2QmP0eM',
-        'mediaId': '9'
-    }
-    mock_author = {
+def make_mock_author(id='1', name='A Test Author', media_id='20'):
+    mock_request = {
         'authorId': id,
         'name': name,
-        'profile_image': mock_profile,
-        'posts': [],
-        'title': ['author', 'staff_writer'],
+        'profile_image': media_id,
+        'title': ['author', 'administrator', 'staff_writer'],
         'description': f'Hi, I am a test author #{id}'
     }
-    return mock_author
+    return mock_request
 
 
 def make_mock_media(id='1', title='Super Cool Pic'):
@@ -57,7 +51,19 @@ def make_mock_media(id='1', title='Super Cool Pic'):
         'source': 'https://bit.ly/2xF5t73',
         'credits': '@123ABC Comp.',
         'caption': 'Super Cool Image',
-        'title': title
+        'title': title,
+        'type': 'cover-image'
+    }
+    return mock_request
+
+
+def make_mock_profile_image(id='20', name='Braden Mars'):
+    """make mock profile image"""
+    mock_request = {
+        "mediaId": id,
+        "source": "https://s.hswstatic.com/gif/landscape-photography-1.jpg",
+        "title": name,
+        "type": "profile-image"
     }
     return mock_request
 
@@ -74,12 +80,10 @@ def make_mock_feedback(guest=True):
 
 def make_mock_category(id='1', name='News'):
     """mock category data"""
-    mock_request = [
-        {
-            'categoryId': id,
-            'name': name
-        }
-    ]
+    mock_request = {
+        'categoryId': id,
+        'name': name
+    }
     return mock_request
 
 
@@ -104,19 +108,3 @@ def make_mock_poll():
         ]
     }
     return mock_request
-# ----
-
-
-def make_fullmock_article(id='10', title='A Cascading Article'):
-    """article mock with full author and media details"""
-    media = make_mock_media()
-    author = make_mock_author(id='2')
-    categories = make_mock_category()
-    categories.extend(make_mock_category(
-        id='2', name='Sports'))
-    del author['posts']
-    post = make_mock_article()
-    post['author'] = author
-    post['cover_image'] = media
-    post['categories'] = categories
-    return post

--- a/tests/test_author.py
+++ b/tests/test_author.py
@@ -15,22 +15,24 @@ from test_setup import ApiTestCase
 class AuthorTest(ApiTestCase):
 
     def test_create_author(self):
+        """Author Creation Test"""
         p = TestPrint('test_create')
         p.info("Testing Author Creation")
-        self.mock_request = make_mock_author()
-        mock_data = json.dumps(self.mock_request)
-        p.data('Mock Request', self.mock_request)
-        req = requests.post(author_url, json=mock_data)
-        reply = req.json()
-        p.data('Json Reply', reply)
-        ser_reply = json.loads(reply)
-        self.mock_request['profile_image'] = ser_reply['profile_image']
+        mock_request = make_mock_author()
+        mock_data = json.dumps(mock_request)
+        p.data('Mock Request', mock_request)
+        _req = requests.post(author_url, json=mock_data)
+        req = json.loads(_req.json())
+        mock_request['profile_image'] = req['profile_image']
         # Title should be parsed from ['administrator', 'staff_writer'] => "Staff Writer"
-        self.mock_request['title'] = "Staff Writer"
-        p.data('Expected', self.mock_request)
-        self.assertDictEqual(self.mock_request, ser_reply)
+        mock_request['title'] = "Staff Writer"
+        # Author should be returned with empty array for posts attribute
+        mock_request['posts'] = []
+        p.data('Expected', mock_request)
+        self.assertDictEqual(mock_request, req)
 
     def test_author_saved(self):
+        """Author DB Save Test"""
         mock_request = make_mock_author(id='2')
         requests.post(author_url, json=json.dumps(mock_request))
         t = TestPrint('test_author_saved')
@@ -41,16 +43,18 @@ class AuthorTest(ApiTestCase):
         )
         t.data('_resp Data', _resp)
         try:
-            resp = _resp['Item']
+            db_item = _resp['Item']
         except KeyError:
             t.info('FAILED')
             scan = self.author_table.scan()
             items = scan["Items"]
             t.data('DATABASE DUMP', items)
-        mock_request['profile_image'] = resp['profile_image']
+            self.fail(f'Author Not Saved to database: {items}')
+        mock_request['profile_image'] = db_item['profile_image']
         mock_request['title'] = "Staff Writer"
+        mock_request['posts'] = []
         t.data('Expected', mock_request)
-        self.assertDictEqual(mock_request, resp)
+        self.assertDictEqual(mock_request, db_item)
 
 
 if __name__ == '__main__':

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -12,7 +12,6 @@ from test_setup import ApiTestCase
 
 
 class MediaTest(ApiTestCase):
-    media_url = "http://127.0.0.1:5000/api/media"
 
     def test_create_cover(self):
         """Create Cover Image Test"""

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -10,50 +10,44 @@ import requests
 from helper import TestPrint
 from sample import (author_url, category_url, make_fullmock_article,
                     make_mock_article, make_mock_author, make_mock_category,
+                    make_mock_media, make_mock_profile_image, media_url,
                     post_url)
 from test_setup import ApiTestCase
 
 
 class PostTest(ApiTestCase):
 
+    def setup_article(self):
+        """Create Article resource requirements"""
+        mock_author_profile = make_mock_profile_image()
+        mock_cover_image = make_mock_media()
+        mock_author = make_mock_author()
+        mock_category = make_mock_category()
+        requests.post(media_url, json=json.dumps(mock_author_profile))
+        requests.post(media_url, json=json.dumps(mock_cover_image))
+        requests.post(author_url, json=json.dumps(mock_author))
+        requests.post(category_url, json=json.dumps(mock_category))
+        return {
+            'authorId': mock_author['authorId'],
+            'category': [mock_category['categoryId']],
+            'cover_img': mock_cover_image['mediaId']
+        }
+
     def test_create_article(self):
         """Create Article Request Test"""
-        mock_author = make_mock_author()
-        requests.post(author_url, json=json.dumps(mock_author))
-        p = TestPrint('test_create_article')
-        p.info(__doc__)
-        mock_author = {
-            'authorId': mock_author['authorId']
-        }
-        self.mock_request = make_mock_article(author=mock_author)
-        mock_data = json.dumps(self.mock_request)
-        p.data('Mock Json', mock_data)
-        req = requests.post(post_url, json=mock_data)
-        reply = req.json()
-        p.data('Json Reply', reply)
-        ser_reply = json.loads(reply)
-        cover_img = ser_reply['cover_image']
-        self.mock_request['cover_image'] = cover_img
-        self.mock_request['authorId'] = ser_reply['authorId']
-        del self.mock_request['author']
-        self.assertDictEqual(self.mock_request, ser_reply)
+        # Create Article
+        article_setup = self.setup_article()
+        mock_request = make_mock_article(**article_setup)
+        _req = requests.post(post_url, json=json.dumps(mock_request))
+        req = json.loads(_req.json())
+        self.assertDictEqual(mock_request, req)
 
     def test_post_update(self):
-        """
-        Test for author saving new post
-        """
-        t = TestPrint('test_post_update (post)')
-        # Create Author
-        mock_author = make_mock_author(id='2')
-        requests.post(author_url, json=json.dumps(mock_author))
-        # Create Article
-        mock_author = {
-            'authorId': mock_author['authorId']
-        }
-        mock_request = make_mock_article(id='1', author=mock_author)
-        mock_data = json.dumps(mock_request)
-        t.data('Mock Json', mock_data)
-        req = requests.post('http://127.0.0.1:5000/api/posts', json=mock_data)
+        """Ensure Post updates Author test"""
+        article_setup = self.setup_article()
+        mock_request = make_mock_article(**article_setup)
+        req = requests.post('http://127.0.0.1:5000/api/posts',
+                            json=json.dumps(mock_request))
         # Check post saved
         _resp = self.post_table.get_item(
             Key={
@@ -68,17 +62,12 @@ class PostTest(ApiTestCase):
             items = scan["Items"]
             t.data('DATABASE DUMP', items)
             self.fail("Post ID not found in database!")
-        mock_request['cover_image'] = resp['cover_image']
-        mock_request['authorId'] = mock_request['author']['authorId']
-        del mock_request['author']
-        t.data('Expected: ', mock_request)
-        t.data('resp Data', resp)
         self.assertDictEqual(mock_request, resp)
         # Check Author Updated
         t = TestPrint('test_post_update (author)')
         _resp = self.author_table.get_item(
             Key={
-                'authorId': mock_author['authorId']
+                'authorId': mock_request['author']
             }
         )
         resp = _resp['Item']
@@ -89,62 +78,33 @@ class PostTest(ApiTestCase):
 
     def test_multi_article_save(self):
         """
-        Test to make sure author is saving multiple posts
+        Test to ensure author is saving multiple posts
         """
         t = TestPrint('test_multi_article_save')
-        _mock_author = make_mock_author(id='2', name='Mock Author Two')
-        author_resp = requests.post(author_url, json=json.dumps(_mock_author))
-        mock_author = {
-            'authorId': _mock_author['authorId'],
-            'name': _mock_author['name']
-        }
+        article_setup = self.setup_article()
         mock_post_1 = make_mock_article(
-            id='5', title='Mock Article #5', author=mock_author)
+            id='5', title='Mock Article #5', **article_setup)
         mock_post_2 = make_mock_article(
-            id='6', title='Mock Article #6', author=mock_author)
+            id='6', title='Mock Article #6', **article_setup)
         _resp_1 = requests.post(post_url, json=json.dumps(mock_post_1))
         _resp_2 = requests.post(post_url, json=json.dumps(mock_post_2))
         resp_1 = json.loads(_resp_1.json())
         resp_2 = json.loads(_resp_2.json())
-        t.data('Response Post 1', resp_1)
-        t.data('Response Post 2', resp_2)
         _resp = self.author_table.get_item(Key={
-            'authorId': '2'
+            'authorId': '1'
         })
         resp = _resp['Item']
         t.data('Received Response', resp)
         expected_posts = [mock_post_1['postId'], mock_post_2['postId']]
         self.assertEqual(expected_posts, resp['posts'])
 
-    def test_post_cascade(self):
-        """Test author and media creation from a new post"""
-        t = TestPrint('test_post_cascade')
-        _mock_post = make_fullmock_article()
-        _req = requests.post(post_url, json=json.dumps(_mock_post))
-        req = json.loads(_req.json())
-        ignore = ['key', 'source', 'type']
-        recv_data = {k: v for k, v in req.items() if k not in ignore}
-        expected = recv_data = {k: v for k,
-                                v in req.items() if k not in ignore}
-        self.assertDictEqual(expected, recv_data)
-
     def test_create_category(self):
-        """Test direct creation of category"""
+        """Test Category Creation"""
         t = TestPrint('test_create_category')
-        mock_request = make_mock_category()[0]
+        mock_request = make_mock_category()
         _req = requests.post(category_url, json=json.dumps(mock_request))
         req = json.loads(_req.json())
         self.assertDictEqual(mock_request, req)
-
-    def test_post_category(self):
-        """Test category creation from post"""
-        t = TestPrint('test_post_category')
-        mock_request = make_fullmock_article()
-        expected = {'categories': mock_request['categories']}
-        _req = requests.post(post_url, json=json.dumps(mock_request))
-        req = json.loads(_req.json())
-        t.data('Post Cat Data', req)
-        self.assertDictContainsSubset(expected, req)
 
 
 if __name__ == '__main__':

--- a/warriorbeat/warriorbeat/api/author/schema.py
+++ b/warriorbeat/warriorbeat/api/author/schema.py
@@ -12,8 +12,8 @@ class AuthorSchema(Schema):
     """Author Schema"""
     authorId = fields.Str(required=True)
     name = fields.Str()
-    profile_image = fields.Nested('ProfileImageSchema')
-    posts = fields.List(fields.Str())
+    profile_image = fields.Pluck('ImageSchema', 'mediaId')
+    posts = fields.Pluck('ArticleSchema', 'postId', many=True)
     title = fields.Method('author_role', deserialize='get_author_role')
     description = fields.Str(
         required=False, allow_none=True, default='Staff Member')

--- a/warriorbeat/warriorbeat/api/author/view.py
+++ b/warriorbeat/warriorbeat/api/author/view.py
@@ -17,8 +17,6 @@ class AuthorList(Resource):
 
     @use_schema(AuthorSchema(), dump=True)
     def post(self, author):
-        profile_image = author.profile_image
-        profile_image.save()
         author.save()
         return author
 

--- a/warriorbeat/warriorbeat/api/category/model.py
+++ b/warriorbeat/warriorbeat/api/category/model.py
@@ -16,5 +16,3 @@ class Category(ResourceModel):
         self.categoryId = categoryId
         self.name = kwargs.get('name')
         self.schema = kwargs.get('schema')
-        if not self.db.exists(self.categoryId):
-            self.save()

--- a/warriorbeat/warriorbeat/api/category/view.py
+++ b/warriorbeat/warriorbeat/api/category/view.py
@@ -16,6 +16,7 @@ class CategoryList(Resource):
 
     @use_schema(CategorySchema(), dump=True)
     def post(self, category):
+        category.save()
         return category
 
 

--- a/warriorbeat/warriorbeat/api/media/model.py
+++ b/warriorbeat/warriorbeat/api/media/model.py
@@ -15,23 +15,23 @@ class Media(ResourceModel):
     db = DynamoDB('media')
     identity = 'mediaId'
 
-    def __init__(self, mediaId, source, **kwargs):
+    def __init__(self, mediaId, **kwargs):
         self.mediaId = mediaId
-        self.source = source
+        self.source = kwargs.get('source')
         self.type = kwargs.get('type', '')
 
 
 class Image(Media):
     """Image Type Media"""
 
-    def __init__(self, title, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.credits = kwargs.get('credits', None)
         self.caption = kwargs.get('caption', None)
         self.type = kwargs.get('type', 'image')
-        self.title = title
+        self.title = kwargs.get('title')
         self.key = kwargs.get('key', '')
         super().__init__(*args, **kwargs)
-        self.set_source()
+        self.get_source()
 
     def set_source(self):
         """download image from url and set source"""
@@ -45,22 +45,4 @@ class Image(Media):
         """generate url for image"""
         url = self.storage.get_url(self.key)
         self.source = url
-        self.save()
         return url
-
-
-class CoverImage(Image):
-    """Cover Image Media Object"""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
-class ProfileImage(Image):
-    """User Profile Image Model"""
-
-    def __init__(self, **kwargs):
-        self.key = 'profile/'
-        super().__init__(key=self.key, **kwargs)
-        self.title = kwargs.get('title')
-        self.type = kwargs.get('type', 'profile-image')

--- a/warriorbeat/warriorbeat/api/media/model.py
+++ b/warriorbeat/warriorbeat/api/media/model.py
@@ -31,7 +31,6 @@ class Image(Media):
         self.title = kwargs.get('title')
         self.key = kwargs.get('key', '')
         super().__init__(*args, **kwargs)
-        self.get_source()
 
     def set_source(self):
         """download image from url and set source"""
@@ -39,10 +38,4 @@ class Image(Media):
         url, file_ext = self.storage.upload_from_url(self.source, key=key)
         self.source = url
         self.key = self.storage.key + key + file_ext
-        return url
-
-    def get_source(self):
-        """generate url for image"""
-        url = self.storage.get_url(self.key)
-        self.source = url
         return url

--- a/warriorbeat/warriorbeat/api/media/schema.py
+++ b/warriorbeat/warriorbeat/api/media/schema.py
@@ -5,7 +5,7 @@
 
 from marshmallow import Schema, fields, post_load
 
-from warriorbeat.api.media.model import CoverImage, ProfileImage
+from warriorbeat.api.media.model import Image
 
 
 class MediaSchema(Schema):
@@ -23,29 +23,9 @@ class ImageSchema(MediaSchema):
     key = fields.Str()
     type = fields.Str(missing='image', default='image')
 
-
-class CoverImageSchema(ImageSchema):
-    """Cover Image Schema"""
-    type = fields.Str(missing='cover-image', default='cover-image')
-
     @post_load
-    def make_cover_image(self, data):
-        """return instance of CoverImage"""
-        cover_img = CoverImage(**data)
-        cover_img.schema = CoverImageSchema()
-        return cover_img
-
-
-class ProfileImageSchema(ImageSchema):
-    """Profile Image Schema"""
-    class Meta:
-        fields = ('title', 'source', 'mediaId', 'type')
-
-    title = fields.Str(data_key='name')
-    type = fields.Str(missing='profile-image', default='profile-image')
-
-    @post_load
-    def make_profile_image(self, data):
-        profile_img = ProfileImage(**data)
-        profile_img.schema = ProfileImageSchema()
-        return profile_img
+    def make_image(self, data):
+        """return image instance"""
+        image = Image.create_or_update(**data)
+        image.schema = ImageSchema()
+        return image

--- a/warriorbeat/warriorbeat/api/media/view.py
+++ b/warriorbeat/warriorbeat/api/media/view.py
@@ -7,7 +7,7 @@
 from flask_restful import Resource
 
 from warriorbeat.api.media.model import Media
-from warriorbeat.api.media.schema import CoverImageSchema
+from warriorbeat.api.media.schema import ImageSchema
 from warriorbeat.utils import use_schema
 
 
@@ -15,8 +15,9 @@ class MediaList(Resource):
     def get(self):
         return Media.all()
 
-    @use_schema(CoverImageSchema(), dump=True)
+    @use_schema(ImageSchema(), dump=True)
     def post(self, media):
+        media.set_source()
         media.save()
         return media
 

--- a/warriorbeat/warriorbeat/api/model.py
+++ b/warriorbeat/warriorbeat/api/model.py
@@ -42,7 +42,8 @@ class ResourceModel:
         """update resource item with new data"""
         item = cls.retrieve(identity)
         deep_merge_dicts(item, data)
-        instance = schema().load(item)
+        schema = schema() if isinstance(schema, type) else schema
+        instance = schema.load(item)
         return instance
 
     @classmethod

--- a/warriorbeat/warriorbeat/api/post/schema.py
+++ b/warriorbeat/warriorbeat/api/post/schema.py
@@ -10,21 +10,19 @@ from warriorbeat.api.post.model import Article
 
 class PostSchema(Schema):
     """Generic Post Schema"""
-    postId = fields.Str(required=True)
-    title = fields.Str(required=True)
+    postId = fields.Str()
+    title = fields.Str()
     date = fields.Str()
     type = fields.Str()
 
 
 class ArticleSchema(PostSchema):
     """Article Post Type Schema"""
-    author = fields.Nested('AuthorSchema', exclude=(
-        'posts', ), load_only=True)
-    authorId = fields.Pluck('AuthorSchema', 'authorId',
-                            attribute='author', dump_only=True)
-    cover_image = fields.Nested('CoverImageSchema')
-    content = fields.Str(required=True)
-    categories = fields.Nested('CategorySchema', many=True)
+
+    author = fields.Pluck('AuthorSchema', 'authorId')
+    cover_image = fields.Pluck('ImageSchema', 'mediaId')
+    content = fields.Str()
+    categories = fields.Pluck('CategorySchema', 'categoryId', many=True)
 
     @post_load
     def make_article(self, data):

--- a/warriorbeat/warriorbeat/api/post/view.py
+++ b/warriorbeat/warriorbeat/api/post/view.py
@@ -19,10 +19,11 @@ class PostList(Resource):
     @use_schema(ArticleSchema(), dump=True)
     def post(self, article):
         author = article.author
-        author = type(author).update_item(author.authorId, {
-            'posts': [article.postId]
-        }, author.schema)
-        author.save()
+        if article.postId not in author.posts:
+            author.posts.append(article.postId)
+            author = type(author).update_item(author.authorId, {
+                'posts': author.posts}, author.schema)
+            author.save()
         article.save()
         return article
 

--- a/warriorbeat/warriorbeat/api/post/view.py
+++ b/warriorbeat/warriorbeat/api/post/view.py
@@ -19,11 +19,10 @@ class PostList(Resource):
     @use_schema(ArticleSchema(), dump=True)
     def post(self, article):
         author = article.author
-        cover_image = article.cover_image
-        if article.postId not in author.posts:
-            author.posts.append(article.postId)
+        author = type(author).update_item(author.authorId, {
+            'posts': [article.postId]
+        }, author.schema)
         author.save()
-        cover_image.save()
         article.save()
         return article
 

--- a/warriorbeat/warriorbeat/utils/data.py
+++ b/warriorbeat/warriorbeat/utils/data.py
@@ -164,7 +164,7 @@ class S3Storage:
         """upload file from url"""
         img_stream = requests.get(url, stream=True)
         content_type = img_stream.headers.get('content-type', 'image/jpeg')
-        file_ext = self.FILE_EXTENSIONS[content_type]
+        file_ext = self.FILE_EXTENSIONS.get(content_type, '.jpeg')
         img_obj = img_stream.raw
         img_data = img_obj.read()
         return (self.upload_obj((img_data, file_ext), **kwargs), file_ext)

--- a/warriorbeat/warriorbeat/utils/data.py
+++ b/warriorbeat/warriorbeat/utils/data.py
@@ -164,7 +164,7 @@ class S3Storage:
         """upload file from url"""
         img_stream = requests.get(url, stream=True)
         content_type = img_stream.headers.get('content-type', 'image/jpeg')
-        file_ext = self.FILE_EXTENSIONS.get(content_type, '.jpeg')
+        file_ext = self.FILE_EXTENSIONS[content_type]
         img_obj = img_stream.raw
         img_data = img_obj.read()
         return (self.upload_obj((img_data, file_ext), **kwargs), file_ext)

--- a/warriorbeat/warriorbeat/utils/utils.py
+++ b/warriorbeat/warriorbeat/utils/utils.py
@@ -27,7 +27,7 @@ def deep_merge_lists(original, incoming):
             deep_merge_lists(original[idx], incoming[idx])
 
         else:
-            orginal[idx] = incoming[idx]
+            original[idx] = incoming[idx]
 
     for idx in range(common_length, len(incoming)):
         original.append(incoming[idx])


### PR DESCRIPTION
### Resource Relationship Restructure 

* Aiming to separate Post Resource and others from the strange nested relationship things that ended up happening. 
* The aim is to have serialized data/relationships represented by purely id(s), not nesting them like crazy. 
* For deserialized, let the schemas handle loading the objects with the proper relationships and sending them to the view

### Schema Cleanup

* With the above changes, most of the data schemas will already be significantly cleaner.
* Schema validations
* Represent relationshios with plucked identification instead of nested data 